### PR TITLE
missleading benchmark results

### DIFF
--- a/caches_bench_test.go
+++ b/caches_bench_test.go
@@ -154,11 +154,19 @@ func MapGet[T any](cs constructor[T], b *testing.B) {
 
 	hitCount := 0
 	for i := 0; i < b.N; i++ {
-		id := rand.Intn(maxEntryCount)
-		if e, ok := m[key(id)]; ok {
+		if e, ok := m["a"]; ok {
 			_ = (T)(e)
 			hitCount++
 		}
+	}
+}
+
+func MapGetBaseline[T any](b *testing.B) {
+	hitCount := 0
+	for i := 0; i < b.N; i++ {
+		id := rand.Intn(maxEntryCount)
+		key(id)
+		hitCount++
 	}
 }
 
@@ -230,8 +238,8 @@ func BigCacheGet[T any](cs constructor[T], b *testing.B) {
 
 	hitCount := 0
 	for i := 0; i < b.N; i++ {
-		id := rand.Intn(maxEntryCount)
-		data, _ := cache.Get(key(id))
+		//id := rand.Intn(maxEntryCount)
+		data, _ := cache.Get("a")
 		v, _ := cs.Parse(data)
 		_ = (T)(v)
 		hitCount++
@@ -260,6 +268,10 @@ func BenchmarkBigCacheGetForStruct(b *testing.B) {
 
 func BenchmarkMapGetForBytes(b *testing.B) {
 	MapGet[[]byte](byteConstructor{}, b)
+}
+
+func BenchmarkMapGetBaseline(b *testing.B) {
+	MapGetBaseline[[]byte](b)
 }
 
 func BenchmarkSyncMapGetForBytes(b *testing.B) {


### PR DESCRIPTION
Hi, 
it's not a real PR but some sample code to demonstrate my idea.
First, thanks for this great project.

I'm trying to include this lib in my project and I was doing some benchmarking comparing native map vs bigcache get for bytes.
I was getting 11ns/op for native map and getting 101ns/op for bigcache on a 4,000,000 string keys. It's 10x slower than native map.

Which is pretty off from your benchmarking result:
```
BenchmarkMapGetForBytes-8                    	23130621	       207.2 ns/op	      23 B/op	       1 allocs/op
BenchmarkBigCacheGetForBytes-8               12868870	       346.8 ns/op	     151 B/op	       3 allocs/op
```
your results indicate 1.6x slower than native map.

looking into your benchmark code, I realize this line  `id := rand.Intn(maxEntryCount)` actually takes most of the time in the benchmark loop. So the current results are misleading to some degree.

it's [not easy](https://github.com/golang/go/issues/27217) to exclude certain code in the loop with timers, since the timer function is also slow compared to fast operations like map lookup. I included a baseline test to give us the time spent on the `rand.Intn`. There should be better ways to narrow down the timer to focus on our target code.

try to run the sample code and you'll know what I mean.

