### PR TITLE
Add freelru to gc overhead comparison

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,12 @@ go 1.19
 require (
 	github.com/allegro/bigcache/v3 v3.1.0
 	github.com/coocood/freecache v1.2.4
+	github.com/elastic/go-freelru v0.9.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1
+	github.com/zeebo/xxh3 v1.0.2
 )
 
-require github.com/cespare/xxhash/v2 v2.2.0 // indirect
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,5 +5,12 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coocood/freecache v1.2.4 h1:UdR6Yz/X1HW4fZOuH0Z94KwG851GWOSknua5VUbb/5M=
 github.com/coocood/freecache v1.2.4/go.mod h1:RBUWa/Cy+OHdfTGFEhEuE1pMCMX51Ncizj7rthiQ3vk=
+github.com/elastic/go-freelru v0.9.0 h1:s9K5Q4xBoQC96XogjymtKDYfcABkoyDUoSIG4vprywg=
+github.com/elastic/go-freelru v0.9.0/go.mod h1:bSdWT4M0lW79K8QbX6XY2heQYSCqD7THoYf82pT/H3I=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/orcaman/concurrent-map/v2 v2.0.1 h1:jOJ5Pg2w1oeB6PeDurIYf6k9PQ+aTITr/6lP/L/zp6c=
 github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q0Jv47PLaNK++uCdOM=
+github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
+github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
+github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=


### PR DESCRIPTION
This PR adds [FreeLRU](https://github.com/elastic/go-freelru) to the GC overhead comparison.
`FreeLRU` is a GC-less and fast "exact" HashMap LRU implementation.

The PR is applied on top of #19, so bette rget that in first and I'll do a rebase then.

**Results**
```
$ go run caches_gc_overhead_comparison.go -cache freelru
Cache:              freelru
Number of entries:  20000000
Number of repeats:  50
Value size:         100
GC pause for startup:  165.204µs
GC pause for freelru: 1.464987ms
```
